### PR TITLE
Fix before quit hook

### DIFF
--- a/procedures/CodeBrowser.ipf
+++ b/procedures/CodeBrowser.ipf
@@ -765,12 +765,14 @@ Function saveReParse()
 	savedVariables[][0] = 0
 End
 
-Function saveResetStorage()
+// Kill all storage objects
+//
+// note: if objects are in use they can not be killed.
+// 		 therefore the function resets all variables before killing
+Function KillStorage()
 	Wave savedVariablesWave = getSaveVariables()
 	Wave/T SavedStringsWave = getSaveStrings()
 	Wave/WAVE SavedWavesWave = getSaveWaves()
-
-	// if objects are in use they can not be killed. reset before killing
 
 	// reset
 	saveReParse()
@@ -890,10 +892,6 @@ Function searchAndDelete(decls, lines, searchString)
 			DeletePoints/M=0 i, 1, decls, lines
 		endif
 	endif
-End
-
-Function searchReset()
-	setGlobalStr("search","")
 End
 
 Function DeletePKGfolder()

--- a/procedures/CodeBrowser_gui.ipf
+++ b/procedures/CodeBrowser_gui.ipf
@@ -175,6 +175,7 @@ End
 Function existsPanel()
 	DoWindow $panel
 	if(V_flag == 0)
+		debugPrint("panel does not exist")
 		return 0
 	endif
 	debugPrint("panel exists")

--- a/procedures/CodeBrowser_hooks.ipf
+++ b/procedures/CodeBrowser_hooks.ipf
@@ -11,7 +11,8 @@ static Function IgorBeforeQuitHook(unsavedExp, unsavedNotebooks, unsavedProcedur
 
 	string expName
 
-	debugprint("called")
+	debugPrint("called")
+	debugPrint("unsavedExp: " + num2str(unsavedExp))
 
 	BeforePanelClose()
 	DoWindow/K CodeBrowser

--- a/procedures/CodeBrowser_hooks.ipf
+++ b/procedures/CodeBrowser_hooks.ipf
@@ -13,15 +13,15 @@ static Function IgorBeforeQuitHook(unsavedExp, unsavedNotebooks, unsavedProcedur
 
 	debugprint("called")
 
-	preparePanelClose()
-	markAsUnInitialized()
+	BeforePanelClose()
+	DoWindow/K CodeBrowser
+	AfterPanelClose()
 
 	if(unsavedExp || unsavedNotebooks || unsavedProcedures)
 		return 0
 	endif
 
 	expName = IgorInfo(1)
-
 	if(!cmpstr(expName, "Untitled"))
 		return 0
 	endif
@@ -40,7 +40,9 @@ End
 static Function IgorBeforeNewHook(igorApplicationNameStr)
 	string igorApplicationNameStr
 
-	preparePanelClose()
+	debugPrint("called")
+	BeforePanelClose()
+
 	return 0
 End
 
@@ -66,38 +68,52 @@ Function initializePanel()
 	setGlobalStr("search", "")
 End
 
-// Prepare for panel closing, must be called before the panel is killed or the experiment closed
-Function preparePanelClose()
-
+// Prepare for panel closing.
+//
+// note: Must be called before the panel is killed or the experiment is closed.
+Function BeforePanelClose()
 	SetIgorHook/K AfterCompiledHook=updatePanel
-	debugPrint("AfterCompiledHook: " + S_info)
+	if(strlen(S_info) > 0)
+		debugPrint("registered hooks with hookType=AfterCompiledHook: " + S_info)
+	else
+		debugPrint("all hookType=AfterCompiledHook deleted")
+	endif
+End
+
+// Clean up after closing panel
+//
+// note: Must be called after the panel was closed
+Function AfterPanelClose()
+	variable cleanOnExit
 
 	if(!existsPanel())
 		return 0
 	endif
 
-	// save panel coordinates to disk
-	STRUCT CodeBrowserPrefs prefs
-	FillPackagePrefsStruct(prefs)
-	SavePackagePrefsToDisk(prefs)
-
-	// reset global gui variables
-	searchReset()
-
-	// delete CodeBrowser related data
-	if(prefs.configCleanOnExit)
-		// storage data will not be saved in experiment
-		saveResetStorage()
-		killGlobalVar("cleanOnExit")
-		killGlobalVar("debuggingEnabled")
+	cleanOnExit = !!getGlobalVar("cleanOnExit")
+	QuitPackagePrefs()
+	if(cleanOnExit)
+		KillStorage()
+		KillPanelObjects()
+		DeletePKGfolder()
 	endif
 End
 
-// if panel does not exist, delete panel-bound var/wave/dfr
-Function killPanelRelatedObjects()
+// Kill panel-bound variables and waves
+//
+// @see KillStorage
+//
+// note: if the waves and variables are still bound to a panel, this function
+//       will only reset them.
+Function KillPanelObjects()
 	Wave/T decl = getDeclWave()
 	Wave/I line = getLineWave()
 
+	// reset
+	setGlobalStr("search","")
+	setGlobalVar("initialized", 0)
+
+	// kill
 	KillWaves/Z decl, line
 	killGlobalStr("search")
 	killGlobalVar("initialized")
@@ -117,9 +133,8 @@ Function panelHook(s)
 			markAsInitialized()
 			break
 		case 2:				// kill
-			preparePanelClose()
-			killPanelRelatedObjects()
-			DeletePKGfolder()
+			BeforePanelClose()
+			AfterPanelClose()
 			hookResult = 1
 			break
 		case 6:				// resize

--- a/procedures/CodeBrowser_preferences.ipf
+++ b/procedures/CodeBrowser_preferences.ipf
@@ -145,8 +145,23 @@ Function SavePackagePrefsToDisk(prefs)
 	SavePackagePreferences kPackageName, kPrefsFileName, kPrefsRecordID, prefs
 End
 
+// Sync all package preferences to disk and kill global variables that were
+// used.
+Function QuitPackagePrefs()
+	// sync
+	STRUCT CodeBrowserPrefs prefs
+	FillPackagePrefsStruct(prefs)
+	SavePackagePrefsToDisk(prefs)
+
+	// kill
+	if(!!prefs.configCleanOnExit)
+		killGlobalVar("cleanOnExit")
+		killGlobalVar("debuggingEnabled")
+	endif
+End
+
 // Used to test SavePackagePreferences /KILL flag added in Igor Pro 6.10B04.
-Function KillPackagePrefs()
+Function ResetPackagePrefs()
 	STRUCT CodeBrowserPrefs prefs
 	SavePackagePreferences /KILL kPackageName, kPrefsFileName, kPrefsRecordID, prefs
 End


### PR DESCRIPTION
fixes #14 

Update of CleanUp Procedures:

* BeforePanelClose()
  * delete hook

* AfterPanelClose()
  * KillStorage()
  * KillPanelObjects()
  * DeletePKGfolder()
  * QuitPackagePrefs()