### PR TITLE
add linenumber for uncompiled procedure

### DIFF
--- a/procedures/CodeBrowser.ipf
+++ b/procedures/CodeBrowser.ipf
@@ -301,6 +301,9 @@ Function addDecoratedFunctions(module, procedure, declWave, lineWave)
 	for(idx = numEntries; idx < (numEntries + numMatches); idx += 1)
 		func = StringFromList(idx, funcList)
 		fi = FunctionInfo(module + "#" + func, procedure)
+		if(!cmpstr(func, "Procedures Not Compiled"))
+			fi = ReplaceNumberByKey("PROCLINE", fi, 0)
+		endif
 		if(isEmpty(fi))
 			debugPrint("macro or other error for " + module + "#" + func)
 		endif


### PR DESCRIPTION
for uncompiled procedures, both: FuntionList and FunctionInfo return a
List with one item "Procedures Not compiled;".
If we encounter a function like this, set the line number for it to
zero.

This will help in uncompiled state to still jump to the correct
position.

fixes #5 