### PR TITLE
Add wmstruct

### DIFF
--- a/procedures/CodeBrowser.ipf
+++ b/procedures/CodeBrowser.ipf
@@ -268,7 +268,7 @@ Function/S createMarkerForType(type)
 End
 
 // Pretty printing of function/macro with additional info
-Function/S formatDecl(funcOrMacro, params, subtypeTag, [returnType])
+Function/S formatDecl(funcOrMacro, params, subtypeTag, returnType)
 	string funcOrMacro, params, subtypeTag, returnType
 
 	if(!isEmpty(subtypeTag))
@@ -276,7 +276,7 @@ Function/S formatDecl(funcOrMacro, params, subtypeTag, [returnType])
 	endif
 
 	string decl
-	if(ParamIsDefault(returnType))
+	if(strlen(returnType) == 0)
 		sprintf decl, "%s(%s)%s", funcOrMacro, params, subtypeTag
 	else
 		sprintf decl, "%s(%s) -> %s%s", funcOrMacro, params, returnType, subtypeTag
@@ -319,7 +319,7 @@ Function addDecoratedFunctions(module, procedure, declWave, lineWave)
 		subtypeTag    = interpretSubtypeTag(StringByKey("SUBTYPE", fi))
 		params        = interpretParameters(fi)
 		declWave[idx][0] = createMarkerForType("function" + specialTag + threadsafeTag)
-		declWave[idx][1] = formatDecl(func, params, subtypeTag, returnType = returnType)
+		declWave[idx][1] = formatDecl(func, params, subtypeTag, returnType)
 		lineWave[idx]    = NumberByKey("PROCLINE", fi)
 		idx += 1
 	endfor
@@ -720,7 +720,7 @@ static Function saveResults(procedure)
 	SaveVariablesWave[procedure.row][2] = getCheckSumTime() // time in micro seconds
 
 	// if function list could not be acquired don't save the checksum
-	if(!numpnts(declWave) || !cmpstr(declWave[0][1], "Procedures Not Compiled() -> "))
+	if(!DimSize(declWave, 0) || !cmpstr(declWave[0][1], "Procedures Not Compiled()")) ///@todo check in all rows.
 		DebugPrint("Function list is not complete")
 		SaveStringsWave[procedure.row][1] = "no checksum"
 	endif

--- a/procedures/CodeBrowser.ipf
+++ b/procedures/CodeBrowser.ipf
@@ -976,7 +976,7 @@ End
 
 // Shows the line/function for the function/macro with the given index into decl
 // With no index just the procedure file is shown
-Function showCode(procedure,[index])
+Function showCode(procedure, [index])
 	string procedure
 	variable index
 

--- a/procedures/CodeBrowser.ipf
+++ b/procedures/CodeBrowser.ipf
@@ -879,18 +879,17 @@ Function/S nicifyProcedureList(list)
 End
 
 // returns code of procedure in module
-Function/S getProcedureText(module, procedureWithoutModule)
-	String module, procedureWithoutModule
-	String strProcedure
+//
+// @param module    independent module
+// @param procedure procedure without module definition
+Function/S getProcedureText(module, procedure)
+	string module, procedure
 
-	if(isProcGlobal(module))
-		debugPrint(module + " is in ProcGlobal")
-		strProcedure = ProcedureText("", 0, procedureWithoutModule)
-		return strProcedure
-	else
-		debugPrint(procedureWithoutModule + " is in " + module)
-		return ProcedureText("", 0, procedureWithoutModule + " [" + module + "]")
+	if(!isProcGlobal(module))
+		procedure = procedure + " [" + module + "]"
 	endif
+
+	return ProcedureText("", 0, procedure)
 End
 
 // Returns 1 if the procedure file has content which we can show, 0 otherwise

--- a/procedures/CodeBrowser.ipf
+++ b/procedures/CodeBrowser.ipf
@@ -53,9 +53,11 @@ static strConstant cstrTypes = "Variable|String|WAVE|NVAR|SVAR|DFREF|FUNCREF|STR
 // Loosely based on the WM procedure from the documentation
 // Returns a human readable string for the given parameter/return type.
 // See the documentation for FunctionInfo for the exact values.
-Function/S interpretParamType(ptype, paramOrReturn)
+Function/S interpretParamType(ptype, paramOrReturn, funcInfo)
 	variable ptype, paramOrReturn
+	string funcInfo
 
+	string typeName
 	string typeStr = ""
 
 	if(paramOrReturn != 0 && paramOrReturn != 1)
@@ -117,7 +119,11 @@ Function/S interpretParamType(ptype, paramOrReturn)
 	elseif(ptype & 0x100)
 		typeStr += "dfref"
 	elseif(ptype & 0x200)
-		typeStr += "struct"
+		if(GetStructureArgument(funcInfo, typeName))
+			typeStr += typeName
+		else
+			typeStr += "struct"
+		endif
 	elseif(ptype & 0x400)
 		typeStr += "funcref"
 	endif
@@ -191,7 +197,7 @@ Function/S interpretParameters(funcInfo)
 
 	for(i = 0; i < numParams; i += 1)
 		sprintf key, "PARAM_%d_TYPE", i
-		paramType = interpretParamType(NumberByKey(key, funcInfo), 1)
+		paramType = interpretParamType(NumberByKey(key, funcInfo), 1, funcInfo)
 
 		if(i == numParams - numOptParams)
 			str += "["
@@ -209,6 +215,34 @@ Function/S interpretParameters(funcInfo)
 	endif
 
 	return str
+End
+
+// check if Function has as a structure as first parameter
+//
+// the structure definition has to be in the first line after the function definition
+//
+// @param[in]  funcInfo        output of FunctionInfo for the function in question
+// @param[out] structureName   matched name of the structure as string.
+//                             Not changed if 0 is returned.
+//
+// @returns 1 if function has such a parameter, 0 otherwise
+Function GetStructureArgument(funcInfo, structureName)
+	string funcInfo
+	string &structureName
+
+	string declaration, re, str0
+
+	if(NumberByKey("PARAM_0_TYPE", funcInfo) & (0x200 | 0x1000)) // struct | pass-by-reference
+		declaration = getFunctionLine(1, funcInfo)
+		re = "(?i)^\s*struct\s+(\w+)\s+"
+		SplitString/E=(re) declaration, str0
+		if(V_flag == 1)
+			structureName = str0
+			return 1
+		endif
+	endif
+
+	return 0
 End
 
 // Returns a cmd for the given fill *and* stroke color
@@ -313,7 +347,7 @@ Function addDecoratedFunctions(module, procedure, declWave, lineWave)
 		if(isEmpty(fi))
 			debugPrint("macro or other error for " + module + "#" + func)
 		endif
-		returnType    = interpretParamType(NumberByKey("RETURNTYPE", fi),0)
+		returnType    = interpretParamType(NumberByKey("RETURNTYPE", fi), 0, fi)
 		threadsafeTag = interpretThreadsafeTag(StringByKey("THREADSAFE", fi))
 		specialTag    = interpretSpecialTag(StringByKey("SPECIAL", fi))
 		subtypeTag    = interpretSubtypeTag(StringByKey("SUBTYPE", fi))
@@ -339,7 +373,7 @@ Function addDecoratedConstants(module, procedureWithoutModule, declWave, lineWav
 	String procText, re, def, name
 
 	// get procedure code
-	procText = getProcedureText(module, procedureWithoutModule)
+	procText = getProcedureText("", 0, module, procedureWithoutModule)
 	numLines = ItemsInList(procText, "\r")
 
 	// search code and return wavLineNumber
@@ -382,7 +416,7 @@ Function addDecoratedMacros(module, procedureWithoutModule, declWave, lineWave)
 	String procText, re, def, name, arguments, type
 
 	// get procedure code
-	procText = getProcedureText(module, procedureWithoutModule)
+	procText = getProcedureText("", 0, module, procedureWithoutModule)
 	numLines = ItemsInList(procText, "\r")
 
 	// search code and return wavLineNumber
@@ -428,7 +462,7 @@ Function addDecoratedStructure(module, procedureWithoutModule, declWave, lineWav
 	string procText, reStart, reEnd, name, StaticKeyword
 
 	// get procedure code
-	procText = getProcedureText(module, procedureWithoutModule)
+	procText = getProcedureText("", 0, module, procedureWithoutModule)
 	numLines = ItemsInList(procText, "\r")
 	if(numLines == 0)
 		debugPrint("no Content in Procedure " + procedureWithoutModule)
@@ -498,7 +532,7 @@ Function addDecoratedMenu(module, procedureWithoutModule, declWave, lineWave)
 	String currentMenu = ""
 
 	// get procedure code
-	procText = getProcedureText(module, procedureWithoutModule)
+	procText = getProcedureText("", 0, module, procedureWithoutModule)
 	numLines = ItemsInList(procText, "\r")
 
 	// search code and return wavLineNumber
@@ -878,18 +912,57 @@ Function/S nicifyProcedureList(list)
 	return niceList
 End
 
-// returns code of procedure in module
+// Get the specified line of code from a function
 //
-// @param module    independent module
-// @param procedure procedure without module definition
-Function/S getProcedureText(module, procedure)
-	string module, procedure
+// @see getProcedureText
+//
+// @param funcInfo  output of FunctionInfo for the function in question
+// @param lineNo    line number relative to the function definition
+//                  set to -1 to return lines before the procedure that are not part of the preceding macro or function
+//                  see `DisplayHelpTopic("ProcedureText")`
+//
+// @returns lines of code from a function inside a procedure file
+Function/S getFunctionLine(lineNo, funcInfo)
+	variable lineNo
+	string funcInfo
+
+	string funcName, module, procedure, context
+	variable linesOfContext
+
+	funcName = StringByKey("NAME", funcInfo)
+	module = StringByKey("INDEPENDENTMODULE", funcInfo)
+	procedure = StringByKey("PROCWIN", funcInfo)
+
+	linesOfContext = lineNo < 0 ? lineNo : 0
+	context = getProcedureText(funcName, linesOfContext, module, procedure)
+
+	if(lineNo < 0)
+		return context
+	endif
+
+	return StringFromList(lineNo, context, "\r")
+End
+
+// get code of procedure in module
+//
+// see `DisplayHelpTopic("ProcedureText")`
+//
+// @param funcName       Name of Function. Leave blank to get full procedure text
+// @param linesOfContext line numbers in addition to the function definition. Set to 0 to return only the function.
+//                       set to -1 to return lines before the procedure that are not part of the preceding macro or function
+// @param module         independent module
+// @param procedure      procedure without module definition
+// @return multi-line string with function definition
+Function/S getProcedureText(funcName, linesOfContext, module, procedure)
+	string funcName, module, procedure
+	variable linesOfContext
 
 	if(!isProcGlobal(module))
+		debugPrint(procedure + " is not in ProcGlobal")
 		procedure = procedure + " [" + module + "]"
 	endif
 
-	return ProcedureText("", 0, procedure)
+	return ProcedureText(funcName, linesOfContext, procedure)
 End
 
 // Returns 1 if the procedure file has content which we can show, 0 otherwise
@@ -1152,7 +1225,7 @@ static Function setCheckSum(procedure)
 
 	timer = timerStart()
 
-	procText = getProcedureText(procedure.module, procedure.name)
+	procText = getProcedureText("", 0, procedure.module, procedure.name)
 	returnValue = setGlobalStr("parsingChecksum", Hash(procText, 1))
 
 	setCheckSumTime(timerStop(timer))

--- a/procedures/CodeBrowser.ipf
+++ b/procedures/CodeBrowser.ipf
@@ -1154,7 +1154,6 @@ static Function setCheckSum(procedure)
 	timer = timerStart()
 
 	procText = getProcedureText(procedure.module, procedure.name)
-	procText = ProcedureText("", 0, procedure.fullname)
 	returnValue = setGlobalStr("parsingChecksum", Hash(procText, 1))
 
 	setCheckSumTime(timerStop(timer))

--- a/procedures/CodeBrowser_utils.ipf
+++ b/procedures/CodeBrowser_utils.ipf
@@ -53,10 +53,17 @@ Function/S addToItemsInList(list, [sep, suffix, prefix])
 	return resultList
 End
 
+// check if the specified module is ProcGlobal
+//
+// @param module string containing the module name
+// @returns 1 if @p module is an empty string or equal to `ProcGlobal`
 Function isProcGlobal(module)
 	string module
 
-	return cmpstr(module, "ProcGlobal") == 0
+	if(strlen(module) == 0 || !cmpstr(module, "ProcGlobal"))
+		return 1
+	endif
+	return 0
 End
 
 // Returns the dimension of the first screen


### PR DESCRIPTION
# Add WM Structure recognition.
fixes https://github.com/byte-physics/igor-code-browser/issues/10 

This will add support for the following parameters:
* `WMWinHookStruct`
* `WMBackgroundStruct`
* *any* other `WM.*Struct`


# Tested using

```igorpro
Structure WMtestStruct
EndStructure

Function MyNormalFunction(s)
	STRUCT WMtestStruct &s
End

Function MyWindowHook(s)
	STRUCT WMWinHookStruct &s

	Variable hookResult = 0

	switch(s.eventCode)
		case 0:				// Activate
			// Handle activate
			break

		case 1:				// Deactivate
			// Handle deactivate
			break

		// And so on . . .
	endswitch

	return hookResult		// 0 if nothing done, else 1
End

Function TestTask(s)		// This is the function that will be called periodically
	STRUCT WMBackgroundStruct &s
	
	Printf "Task %s called, ticks=%d\r", s.name, s.curRunTicks
	return 0	// Continue background task
End

Function StartTestTask()
	Variable numTicks = 2 * 60		// Run every two seconds (120 ticks)
	CtrlNamedBackground Test, period=numTicks, proc=TestTask
	CtrlNamedBackground Test, start
End

```

produces the followng decls:

```
\k(0,0,0)\K(0,0,0)\W522	WMtestStruct
\k(0,0,0)\K(0,0,0)\W529	[WMtestStruct] MyNormalFunction(struct&) -> var
\k(0,0,0)\K(0,0,0)\W529	[WMWinHookStruct] MyWindowHook(struct&) -> var
\k(0,0,0)\K(0,0,0)\W529	[WMBackgroundStruct] TestTask(struct&) -> var
\k(0,0,0)\K(0,0,0)\W529	StartTestTask() -> var
```