### PR TITLE
saveLoad: Use wave indexing to avoid duplicated code

### DIFF
--- a/procedures/CodeBrowser.ipf
+++ b/procedures/CodeBrowser.ipf
@@ -816,8 +816,7 @@ static Function saveLoad(procedure)
 
 	WAVE/T load0 = SaveWavesWave[procedure.row][0]
 	WAVE/I load1 = SaveWavesWave[procedure.row][1]
-	declWave[][0] = load0[p][0]
-	declWave[][1] = load0[p][1]
+	declWave[][0, 1] = load0[p][q]
 	lineWave[] = load1[p]
 
 	debugPrint("save state loaded successfully")


### PR DESCRIPTION
We can't use Multithread here as IP6 can not use Multithread with text
waves.