### PR TITLE
addDecoratedMenu: Kill S_filename global after Grep call

### DIFF
--- a/procedures/CodeBrowser.ipf
+++ b/procedures/CodeBrowser.ipf
@@ -545,6 +545,7 @@ Function addDecoratedMenu(module, procedureWithoutModule, declWave, lineWave)
 	Wave W_Index
 	Duplicate/FREE W_Index wavLineNumber
 	KillWaves/Z W_Index
+	KillStrings/Z S_filename
 	if(!numMatches)
 		return 0
 	endif


### PR DESCRIPTION
Forgotten in 624a1cdc (include Menus, 2018-12-05).

In the long term we want a wrapper for `Grep` I guess.