### PR TITLE
fix parseProcedure()

### DIFF
--- a/procedures/CodeBrowser.ipf
+++ b/procedures/CodeBrowser.ipf
@@ -717,7 +717,7 @@ Function/S parseProcedure(procedure, [checksumIsCalculated])
 	resetLists(decls, lines, procs, helps)
 	addDecoratedFunctions(procedure, decls, lines)
 
-	WAVE/T procContent = getProcedureTextAsWave(procedure.module, procedure.fullName)
+	WAVE/T procContent = getProcedureTextAsWave(procedure.module, procedure.name)
 	addDecoratedConstants(procContent, decls, lines)
 	addDecoratedMacros(procContent, decls, lines)
 	addDecoratedStructure(procContent, decls, lines)


### PR DESCRIPTION
getProcedureTextAsWave needs procedure without module as input as it adds the module to the procedure when not in ProcGlobal.