### PR TITLE
Compile procedures on loading the panel

### DIFF
--- a/procedures/CodeBrowser.ipf
+++ b/procedures/CodeBrowser.ipf
@@ -1470,3 +1470,8 @@ static Structure procedure
 	String module
 	String fullName
 Endstructure
+
+/// @brief compile all procedures
+Function compile()
+	Execute/P/Z/Q "COMPILEPROCEDURES "
+End

--- a/procedures/CodeBrowser_gui.ipf
+++ b/procedures/CodeBrowser_gui.ipf
@@ -38,6 +38,8 @@ Function createPanel()
 	STRUCT CodeBrowserPrefs prefs
 	LoadPackagePrefsFromDisk(prefs)
 
+	compile()
+
 	if(existsPanel())
 		DoWindow/F $panel
 		return NaN


### PR DESCRIPTION
Loading the CB panel is done using `createPanel()`. Call a function that
forces uncompiled procedures to compile before any additional parsing
happens. This allows also to compile procedures by pressing <kbd>Ctrl</kbd>+<kbd>0</kbd>

Closes #50