### PR TITLE
Reset Panel

### DIFF
--- a/procedures/CodeBrowser.ipf
+++ b/procedures/CodeBrowser.ipf
@@ -12,6 +12,7 @@
 Menu "CodeBrowser"
 	// CTRL+0 is the keyboard shortcut
 	"Open/0", /Q, CodeBrowserModule#CreatePanel()
+	"Reset", /Q, CodeBrowserModule#ResetPanel()
 End
 
 // Markers for the different listbox elements

--- a/procedures/CodeBrowser_gui.ipf
+++ b/procedures/CodeBrowser_gui.ipf
@@ -42,8 +42,7 @@ Function createPanel()
 		return NaN
 	endif
 
-	// Remove floating if using Resize Controls Panel
-	NewPanel/FLT=1/N=$panel/K=1/W=(panelLeft, panelTop, panelLeft + panelWidth, panelTop + panelHeight)
+	NewPanel/N=$panel/K=1/W=(panelLeft, panelTop, panelLeft + panelWidth, panelTop + panelHeight)
 
 	setGlobalStr("procFilter", prefs.procFilter)
 	setGlobalStr("search", prefs.search)
@@ -132,7 +131,6 @@ Function CodeBrowserPanel()
 	SetWindow kwTopWin,userdata(ResizeControlsInfoUGHR)=  "NAME:UGHR;WIN:CodeBrowser;TYPE:User;HORIZONTAL:0;POSITION:300.00;GUIDE1:FR;GUIDE2:;RELPOSITION:5;"
 
 	SetWindow kwTopWin, hook(mainHook)=CodeBrowserModule#panelHook
-	SetActiveSubwindow _endfloat_
 End
 
 Function resizeToPackagePrefs()

--- a/procedures/CodeBrowser_gui.ipf
+++ b/procedures/CodeBrowser_gui.ipf
@@ -30,10 +30,20 @@ Function/S GetPanel()
 	return panel
 End
 
+Function ResetPanel()
+	KillWindow $GetPanel()
+	ResetPackagePrefs()
+	CreatePanel(resize=0)
+End
+
 // Creates the main panel
-Function createPanel()
+Function createPanel([resize])
+	variable resize
+
 	STRUCT CodeBrowserPrefs prefs
 	LoadPackagePrefsFromDisk(prefs)
+
+	resize = ParamIsDefault(resize) ? 1 : !!resize
 
 	compile()
 
@@ -58,7 +68,9 @@ Function createPanel()
 	ListBox List1, win=$panel, selRow=prefs.panelElement, row=prefs.panelTopElement
 	Checkbox CheckboxSort, win=$panel, value=prefs.panelCheckboxSort
 
-	resizeToPackagePrefs()
+	if(resize)
+		resizeToPackagePrefs()
+	endif
 	DoUpdate/W=$panel
 	initializePanel()
 End


### PR DESCRIPTION
The CodeBrowser Panel was sometimes not visible in a loaded experiment. The new functionality resets all stored panel variables to the default values and skips the resize / move to the old position.