### PR TITLE
Codebrowser updates its state now in background when panel is closed

### DIFF
--- a/procedures/CodeBrowser_gui.ipf
+++ b/procedures/CodeBrowser_gui.ipf
@@ -33,6 +33,11 @@ End
 Function ResetPanel()
 	KillWindow $GetPanel()
 	ResetPackagePrefs()
+
+	KillStorage()
+	KillPanelObjects()
+	DeletePKGfolder()
+
 	CreatePanel(resize=0)
 End
 
@@ -44,8 +49,6 @@ Function createPanel([resize])
 	LoadPackagePrefsFromDisk(prefs)
 
 	resize = ParamIsDefault(resize) ? 1 : !!resize
-
-	compile()
 
 	if(existsPanel())
 		DoWindow/F $panel
@@ -301,6 +304,8 @@ Function/S getCurrentItem([module, procedure, index])
 
 		if(V_Value > 0)
 			return S_Value
+		else
+			return CB_selectAll
 		endif
 	elseif(index)
 		ControlInfo/W=$panel List1

--- a/procedures/CodeBrowser_hooks.ipf
+++ b/procedures/CodeBrowser_hooks.ipf
@@ -9,6 +9,14 @@
 // This source code is licensed under the BSD 3-Clause license found in the
 // LICENSE file in the root directory of this source tree.
 
+static Function AfterCompiledHook()
+
+	if(!existsPanel())
+		saveReParse()
+		loadProcedures(CB_selectAll)
+	endif
+End
+
 static Function IgorBeforeQuitHook(unsavedExp, unsavedNotebooks, unsavedProcedures)
 	variable unsavedExp, unsavedNotebooks, unsavedProcedures
 
@@ -95,13 +103,7 @@ Function AfterPanelClose()
 		return 0
 	endif
 
-	cleanOnExit = !!getGlobalVar("cleanOnExit")
 	QuitPackagePrefs()
-	if(cleanOnExit)
-		KillStorage()
-		KillPanelObjects()
-		DeletePKGfolder()
-	endif
 End
 
 // Kill panel-bound variables and waves


### PR DESCRIPTION
It is also aware of uncompiled state and adds to the buffered declaration a
? indicating that it might have changed for procedure windows that were modified.