### PR TITLE
IgorBeforeQuitHook: Remove it to make it safer

### DIFF
--- a/procedures/CodeBrowser_hooks.ipf
+++ b/procedures/CodeBrowser_hooks.ipf
@@ -20,31 +20,16 @@ End
 static Function IgorBeforeQuitHook(unsavedExp, unsavedNotebooks, unsavedProcedures)
 	variable unsavedExp, unsavedNotebooks, unsavedProcedures
 
-	string expName
+	variable modified
 
-	debugPrint("called")
-	debugPrint("unsavedExp: " + num2str(unsavedExp))
+	ExperimentModified
+	modified = V_flag
 
 	BeforePanelClose()
 	DoWindow/K CodeBrowser
 	AfterPanelClose()
 
-	if(unsavedExp || unsavedNotebooks || unsavedProcedures)
-		return 0
-	endif
-
-	expName = IgorInfo(1)
-	if(!cmpstr(expName, "Untitled"))
-		return 0
-	endif
-
-	// experiment saved and pxp still exists -> silently save it
-	// does not support unpacked experiments
-	GetFileFolderInfo/P=home/Q/Z expName + ".pxp"
-	if(!V_Flag)
-		SaveExperiment
-		return 1
-	endif
+	ExperimentModified modified
 
 	return 0
 End


### PR DESCRIPTION
We have a report of a user where the experiment was saved although it
should not have been.

This could not be reproduced here, but still the current approach is
inherently dangerous.

We now store and restore the experiment modified state surrounding the
panel closing and cleanup.

This does not make the Codebrowser panel closed in the saved experiment
nor does it cleanup its internal data. But we can live with these
drawbacks.